### PR TITLE
UL-96 - refactor(Message): Update fields to be null or have initial data

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+  Thanks for contributing!
+
+  Provide a description of your changes below and a general summary in the title
+
+  Please look at the following checklist to ensure that your PR can be accepted quickly:
+-->
+
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Type of Change
+
+<!--- Put an `x` in all the boxes that apply: -->
+
+- [ ] ✨ New feature (non-breaking change which adds functionality)
+- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
+- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] 🧹 Code refactor
+- [ ] ✅ Build configuration change
+- [ ] 📝 Documentation
+- [ ] 🧪 Tests
+- [ ] 🗑️ Chore

--- a/lib/raygun.dart
+++ b/lib/raygun.dart
@@ -30,11 +30,11 @@ class Message {
   late String conversationId;
   late DID sender;
   late DateTime date;
-  late bool pinned;
-  late List<Reaction> reactions;
-  late String? replied;
+  bool pinned = false;
+  List<Reaction> reactions = [];
+  String? replied;
   late List<String> value;
-  late Map<String, String>? metadata;
+  Map<String, String>? metadata;
   Message(Pointer<G_Message> pointer) {
     Pointer<Char> pId = bindings.message_id(pointer);
     id = pId.cast<Utf8>().toDartString();
@@ -46,7 +46,7 @@ class Message {
     sender = DID(pSender);
 
     Pointer<Char> pDate = bindings.message_date(pointer);
-    
+
     // Rust Chrono uses "UTC" while in dart, UTC is identified by "Z"
     String rawDate = pDate.cast<Utf8>().toDartString().replaceAll(" UTC", 'Z');
 


### PR DESCRIPTION
### 1. Change some fields in Message class, these fields are not obligated, so they can be null or have initial data

![image](https://user-images.githubusercontent.com/63157656/190450964-5b5003e8-9b50-44af-9308-40b0dc6b200c.png)

### 2. Add a template for future PRs